### PR TITLE
Account for timezone name changes when building timezone lookup

### DIFF
--- a/lib/DateTimeX/TZPicker.pm
+++ b/lib/DateTimeX/TZPicker.pm
@@ -127,11 +127,15 @@ sub _build_zones_for_country {
   my %zones_for_country;
   for my $country ($self->known_countries) {
     my @names_in_country = DateTime::TimeZone->names_in_country($country);
-    while (my ($idx, $name) = each @names_in_country) {
+
+    for my $i (0 .. $#names_in_country) {
+      my $name = $names_in_country[$i];
+
       if (exists $links->{$name}) {
-        @names_in_country[$idx] = $links->{$name};
+        $names_in_country[$i] = $links->{$name};
       }
     }
+
     $zones_for_country{$country} = [
       sort { $zone->{$a}{name} cmp $zone->{$b}{name} }
       grep {; exists $zone->{$_} }

--- a/lib/DateTimeX/TZPicker.pm
+++ b/lib/DateTimeX/TZPicker.pm
@@ -122,13 +122,20 @@ sub _build_zones_for_country {
   my ($self) = @_;
 
   my $zone = $self->_zone_lookup;
+  my $links = DateTime::TimeZone->links;
 
   my %zones_for_country;
   for my $country ($self->known_countries) {
+    my @names_in_country = DateTime::TimeZone->names_in_country($country);
+    while (my ($idx, $name) = each @names_in_country) {
+      if (exists $links->{$name}) {
+        @names_in_country[$idx] = $links->{$name};
+      }
+    }
     $zones_for_country{$country} = [
       sort { $zone->{$a}{name} cmp $zone->{$b}{name} }
       grep {; exists $zone->{$_} }
-      DateTime::TimeZone->names_in_country($country)
+      @names_in_country
     ];
   }
 


### PR DESCRIPTION
This fixes a bug where countries that have deprecated timezone names end up with no timezones at all!

As an example, Cambodia's old timezone used to be 'Asia/Phnom_Pehn', but that was deprecated in favor of 'Asia/Bangkok'.

`TZPicker.pm` gets its timezone names from the array returned by `DateTime::TimeZone->all_names`, but that array does not include old timezone names.

In order to make the `_build_zone_lookup` subroutine account for timezone names that have changed, we need to update this array with the new timezone names where appropriate and use that instead. Luckily, `DateTime::TimeZone->links` provides us with a hash that maps all of the old timezone names to the new ones.